### PR TITLE
Fix doc annotations

### DIFF
--- a/rts/Rml/SolLua/bind/Document.cpp
+++ b/rts/Rml/SolLua/bind/Document.cpp
@@ -124,7 +124,7 @@ namespace Rml::SolLua
 
 		/***
 		 * Document derives from Element. Document has no constructor; it must be instantiated through a Context object instead, either by loading an external RML file or creating an empty document. It has the following functions and properties:
-		 * @class RmlUi.Document:RmlUi.Element
+		 * @class RmlUi.Document : RmlUi.Element
 		 * @field context RmlUi.Context
 		 * @field title string
 		 * @field url string

--- a/rts/Rml/SolLua/bind/Element.cpp
+++ b/rts/Rml/SolLua/bind/Element.cpp
@@ -198,9 +198,18 @@ namespace Rml::SolLua
 		/***
 		 * Event listener interface
 		 * @class RmlUi.EventListener
-		 * @field ProcessEvent fun(event: RmlEvent)
-		 * @field OnAttach fun(element: RmlUi.Element) 
-		 * @field OnDetach fun(element: RmlUi.Element)
+		 */
+		/***
+		 * @function RmlUi.EventListener.ProcessEvent
+		 * @param event RmlEvent
+		 */
+		/***
+		 * @function RmlUi.EventListener.OnAttach
+		 * @param element RmlUi.Element
+		 */
+		/***
+		 * @function RmlUi.EventListener.OnDetach
+		 * @param element RmlUi.Element
 		 */ 
 		namespace_table.new_usertype<Rml::EventListener>("EventListener", sol::no_constructor,
 			// M

--- a/rts/Rml/SolLua/bind/ElementDerived.cpp
+++ b/rts/Rml/SolLua/bind/ElementDerived.cpp
@@ -42,7 +42,7 @@ namespace Rml::SolLua
 	void bind_element_derived(sol::table& namespace_table)
 	{
 		/***
-		 * @class RmlUi.ElementText:RmlUi.Element
+		 * @class RmlUi.ElementText : RmlUi.Element
 		 * @field text string
 		 */
 		namespace_table.new_usertype<Rml::ElementText>("ElementText", sol::no_constructor,
@@ -55,8 +55,8 @@ namespace Rml::SolLua
 
 		///////////////////////////
 		/***
-		 * @class RmlUi.ElementTabSet:RmlUi.Element
-		 * @field active_tab integer 
+		 * @class RmlUi.ElementTabSet : RmlUi.Element
+		 * @field active_tab integer
 		 * @field num_tabs integer
 		 */
 
@@ -99,7 +99,7 @@ namespace Rml::SolLua
 
 		//--
 		/***
-		 * @class RmlUi.ElementProgress:RmlUi.Element
+		 * @class RmlUi.ElementProgress : RmlUi.Element
 		 * @field value number
 		 * @field max number
 		 */

--- a/rts/Rml/SolLua/bind/ElementForm.cpp
+++ b/rts/Rml/SolLua/bind/ElementForm.cpp
@@ -137,7 +137,7 @@ namespace Rml::SolLua
 	void bind_element_form(sol::table& namespace_table)
 	{
 		/***
-		 * @class RmlUi.ElementForm:RmlUi.Element
+		 * @class RmlUi.ElementForm : RmlUi.Element
 		 */
 
 		/***
@@ -155,10 +155,10 @@ namespace Rml::SolLua
 
 		///////////////////////////
 		/***
-		 * @class RmlUi.ElementFormControl:RmlUi.Element
+		 * @class RmlUi.ElementFormControl : RmlUi.Element
 		 * @field disabled boolean
-		 * @field name string 
-		 * @field value string 
+		 * @field name string
+		 * @field value string
 		 * @field submitted boolean
 		 */
 		namespace_table.new_usertype<Rml::ElementFormControl>("ElementFormControl", sol::no_constructor,
@@ -177,10 +177,10 @@ namespace Rml::SolLua
 
 		///////////////////////////
 		/***
-		 * @class RmlUi.ElementFormControlInput: RmlUi.Element, RmlUi.ElementFormControl
-		 * @field checked boolean 
-		 * @field maxlength integer 
-		 * @field size int 
+		 * @class RmlUi.ElementFormControlInput : RmlUi.Element, RmlUi.ElementFormControl
+		 * @field checked boolean
+		 * @field maxlength integer
+		 * @field size int
 		 * @field max int
 		 * @field min int
 		 * @field step int
@@ -215,7 +215,7 @@ namespace Rml::SolLua
 			"value", &options::SelectOptionsProxyNode::Value
 		);
 		/***
-		 * @class RmlUi.ElementFormControlSelect: RmlUi.Element, RmlUi.ElementFormControl
+		 * @class RmlUi.ElementFormControlSelect : RmlUi.Element, RmlUi.ElementFormControl
 		 * @field options RmlUi.OptionsProxy
 		 */
 
@@ -255,7 +255,7 @@ namespace Rml::SolLua
 
 		///////////////////////////
 		/***
-		 * @class RmlUi.ElementFormControlTextArea: RmlUi.Element, RmlUi.ElementFormControl
+		 * @class RmlUi.ElementFormControlTextArea : RmlUi.Element, RmlUi.ElementFormControl
 		 * @field cols integer
 		 * @field maxlength integer
 		 * @field rows integer

--- a/rts/Rml/SolLua/bind/Event.cpp
+++ b/rts/Rml/SolLua/bind/Event.cpp
@@ -78,7 +78,7 @@ namespace Rml::SolLua
 		);
 
 		/***
-		 * --- @alias RmlUi.EventParametersProxy.MouseButton
+		 * @alias RmlUi.EventParametersProxy.MouseButton
 		 * | 0 # Left
 		 * | 1 # Right
 		 * | 2 # Middle

--- a/rts/Rml/SolLua/bind/Vector.cpp
+++ b/rts/Rml/SolLua/bind/Vector.cpp
@@ -81,7 +81,7 @@ namespace Rml::SolLua
 		/***
 		 * Two-dimensional float vector
 		 * @see float2
-		 * @class RmlUi.Vector2f.
+		 * @class RmlUi.Vector2f
 		 * @field magnitude number
 		 * @field x number
 		 * @field y number


### PR DESCRIPTION
Various fixes to your PR

Problems

- https://github.com/rhys-vdw/lua-doc-extractor/issues/58
  I will have a fix for this soon! You'll have to wait though.

- https://github.com/rhys-vdw/lua-doc-extractor/issues/59
  I probably won't fix this immediately, so I've added spaces. I think it's clearer with spaces to differentiate it from functions that are also defined as `Foo:Bar()`—but I will aim to fix this in lua-doc-extractor eventually.

- https://github.com/rhys-vdw/lua-doc-extractor/issues/60
  Massive bug! I didn't notice this because I never leave trailing whitespace. Will fix this ASAP, but I've just trimmed your whitespace for now.